### PR TITLE
Feature/converterPressao

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,54 @@
+# Prerequisites
+*.d
+
+# Object files
+*.o
+*.ko
+*.obj
+*.elf
+
+# Linker output
+*.ilk
+*.map
+*.exp
+
+# Precompiled Headers
+*.gch
+*.pch
+
+# Libraries
+*.lib
+*.a
+*.la
+*.lo
+
+# Shared objects (inc. Windows DLLs)
+*.dll
+*.so
+*.so.*
+*.dylib
+
+# Executables
+*.exe
+*.out
+*.app
+*.i*86
+*.x86_64
+*.hex
+
+# Debug files
+*.dSYM/
+*.su
+*.idb
+*.pdb
+
+# Kernel Module Compile Results
+*.mod*
+*.cmd
+.tmp_versions/
+modules.order
+Module.symvers
+Mkfile.old
+dkms.conf
+
+.dist/

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,12 @@
+all: compile
+
+CC = gcc
+SOURCES = ./*.c
+
+.PHONY: clean
+
+clean:
+	rm -f conversor
+
+compile:
+	$(CC) $(SOURCES) -o conversor

--- a/main.c
+++ b/main.c
@@ -13,7 +13,7 @@ void sair(void);
 
 
 int main(void) {
-    setlocale(LC_ALL, ""); // Configura o uso de UTF-8
+    setlocale(LC_CTYPE, "pt_BR.UTF-8"); // Configura o uso de UTF-8
     int resposta;
 
     do {
@@ -30,10 +30,10 @@ int main(void) {
         printf("-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=\n");
         printf("Escolha uma opção: ");
 
-        if (scanf("%d", &resposta) != 1) { 
+        if (scanf("%d", &resposta) != 1) {
             printf("\nEntrada inválida. Por favor, insira um número de 1 a 8.\n");
-            while (getchar() != '\n'); 
-            continue; 
+            while (getchar() != '\n');
+            continue;
         }
 
         switch (resposta) {
@@ -65,7 +65,7 @@ int main(void) {
             printf("\nOpção inválida. Por favor, escolha um número entre 1 e 8.\n");
             break;
         }
-    } while (resposta != 8); 
+    } while (resposta != 8);
 
     return 0;
 }

--- a/massa.c
+++ b/massa.c
@@ -35,8 +35,3 @@ void converterMassa(void) {
         printf("Opcao invalida. Por favor, escolha unidades validas.\n");
     }
 }
-
-int main() {
-    converterMassa();
-    return 0;
-}

--- a/pressao.c
+++ b/pressao.c
@@ -1,0 +1,57 @@
+#include <stdio.h>
+
+void converterPressao(void) {
+    float valor, resultado;
+    int unidadeOrigem, unidadeDestino;
+
+    // Solicita ao usuário a unidade de medida inicial
+    printf("\nQual e a unidade de medida inicial?\n");
+    printf("1. Pascal (Pa)\n");
+    printf("2. Pressão Atmosférica (atm)\n");
+    printf("Escolha uma opcao (1 ou 2): ");
+    scanf("%d", &unidadeOrigem);
+
+    // Solicita ao usuário o valor na unidade escolhida
+    printf("\nDigite o valor a ser convertido: ");
+    scanf("%f", &valor);
+
+    // Solicita ao usuário a unidade para a qual deseja converter
+    printf("\nPara qual unidade voce quer converter?\n");
+	printf("1. Pascal (Pa)\n");
+    printf("2. Pressão Atmosférica (atm)\n");
+    printf("Escolha uma opcao (1 ou 2): ");
+    scanf("%d", &unidadeDestino);
+
+	switch (unidadeOrigem) {
+	case 1:
+		switch (unidadeDestino) {
+		case 1:
+			printf("O valor permanece o mesmo: %.4f.\n", valor);
+			break;
+		case 2:
+			resultado = valor / 101325; // Pascal para Pressão Atmosférica
+			printf("%.4f Pa equivalem a %.4f atm.\n", valor, resultado);
+			break;
+		default:
+			printf("Opcao invalida. Por favor, escolha unidades validas.\n");
+			break;
+		}
+		break;
+	case 2:
+		switch (unidadeDestino) {
+		case 1:
+			resultado = valor * 101325; // Pressão Atmosférica para Pascal
+			printf("%.4f atm equivalem a %.4f Pa.\n", valor, resultado);
+			break;
+		case 2:
+			printf("O valor permanece o mesmo: %.4f.\n", valor);
+			break;
+		default:
+			printf("Opcao invalida. Por favor, escolha unidades validas.\n");
+			break;
+		}
+		break;
+	default:
+		printf("Opcao invalida. Por favor, escolha unidades validas.\n");
+	}
+}

--- a/pressao.c
+++ b/pressao.c
@@ -8,6 +8,7 @@ void converterPressao(void) {
     printf("\nQual e a unidade de medida inicial?\n");
     printf("1. Pascal (Pa)\n");
     printf("2. Pressão Atmosférica (atm)\n");
+	printf("3. Milímetros de Mercúrio (mmHg)\n");
     printf("Escolha uma opcao (1 ou 2): ");
     scanf("%d", &unidadeOrigem);
 
@@ -19,6 +20,7 @@ void converterPressao(void) {
     printf("\nPara qual unidade voce quer converter?\n");
 	printf("1. Pascal (Pa)\n");
     printf("2. Pressão Atmosférica (atm)\n");
+	printf("3. Milímetros de Mercúrio (mmHg)\n");
     printf("Escolha uma opcao (1 ou 2): ");
     scanf("%d", &unidadeDestino);
 
@@ -32,6 +34,10 @@ void converterPressao(void) {
 			resultado = valor / 101325; // Pascal para Pressão Atmosférica
 			printf("%.4f Pa equivalem a %.4f atm.\n", valor, resultado);
 			break;
+		case 3:
+			resultado = valor / 133.322; // Pascal para Milímetros de Mercúrio
+			printf("%.4f Pa equivalem a %.4f mmHg.\n", valor, resultado);
+			break;
 		default:
 			printf("Opcao invalida. Por favor, escolha unidades validas.\n");
 			break;
@@ -44,6 +50,28 @@ void converterPressao(void) {
 			printf("%.4f atm equivalem a %.4f Pa.\n", valor, resultado);
 			break;
 		case 2:
+			printf("O valor permanece o mesmo: %.4f.\n", valor);
+			break;
+		case 3:
+			resultado = valor * 760; // Pressão Atmosférica para Milímetros de Mercúrio
+			printf("%.4f atm equivalem a %.4f mmHg.\n", valor, resultado);
+			break;
+		default:
+			printf("Opcao invalida. Por favor, escolha unidades validas.\n");
+			break;
+		}
+		break;
+	case 3:
+		switch (unidadeDestino) {
+		case 1:
+			resultado = valor * 133.322; // Milímetros de Mercúrio para Pascal
+			printf("%.4f mmHg equivalem a %.4f Pa.\n", valor, resultado);
+			break;
+		case 2:
+			resultado = valor / 760; // Milímetros de Mercúrio para Pressão Atmosférica
+			printf("%.4f mmHg equivalem a %.4f atm.\n", valor, resultado);
+			break;
+		case 3:
 			printf("O valor permanece o mesmo: %.4f.\n", valor);
 			break;
 		default:


### PR DESCRIPTION
Este PR implementa a função de conversão entre unidades de Pressão, especificamente _Pascal (Pa)_, _Pressão Atmosférica (atm)_ e _Milímetro de Mercúrio (mmHg)_.

---

Também foi implementado um `Makefile` bem simples para agilizar o processo de compilação. Com o `make` instalado na sua máquina, basta digitar no terminal:

```bash
make
```

para compilar a aplicação, onde será gerado um arquivo executável de saída nomeado `conversor`; ou então

```bash
make clean
```

para excluir o arquivo de saída gerado.

Vale ressaltar que este `Makefile` não faz a verificação/auto tratamento das funções ausentes, então funções ainda não implementadas devem ser implementadas, ou então comentadas no código para que não haja erro de compilação, da mesma forma como ocorreria se a compilação fosse feita diretamente pelo `gcc`.

---

Além disso, algumas outras mudanças e correções também foram feitas:

* Altera `gitignore.txt` para o padrão (i.e. `.gitignore`);
* Adiciona a pasta `.dist/` gerada pelo _vscode_ na lista de exclusão do `.gitignore`;
* Remove a função `main()` do arquivo `massa.c` para evitar erros de múltiplas referências à `main` durante o processo de compilação;
* Altera a categoria do `setlocale()` para `LC_CTYPE` ao invés de `LC_ALL`, para que apenas sejam modificados os caracteres, assim permitindo o uso de acentuação, mas mantendo, por exemplo, o divisor das casas decimais como sendo o ponto, ao invés da vírgula;
* Define o `locale` do `setlocale()` como `pt_BR.UTF-8` para garantir que sejam usados os caracteres Unicode disponíveis para o português brasileiro.